### PR TITLE
Harden against accidental leaking of the password

### DIFF
--- a/polysafe.html
+++ b/polysafe.html
@@ -54,7 +54,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </head>
 
 <body>
-    <form>
+    <noscript>
+        PolySafe will not work without JavaScript enabled!<br/>
+    </noscript>
+    <form action="javascript:;" style="display:none">
         <div class="grid-1-l">
             <label for="file">File to encrypt:</label>
         </div>
@@ -277,6 +280,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             e.preventDefault();
             runEncrypt();
         });
+        document.querySelector('form').style.display = 'block';
 
         const DECRYPTOR_TEMPLATE =
             `

--- a/polysafe.html
+++ b/polysafe.html
@@ -290,7 +290,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 </head>
 
 <body>
-    <form>
+    <noscript>
+        Decryption will not work without JavaScript enabled!<br/>
+    </noscript>
+    <form action="javascript:;" style="display:none">
         <label for="password">Password:</label>
         <input type="password" autofocus>
         <input type="submit" value="Decrypt file">
@@ -416,6 +419,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             e.preventDefault();
             runDecrypt();
         });
+        document.querySelector('form').style.display = 'block';
     <\/script>
 </body>
 


### PR DESCRIPTION
In order to prevent submission of the password form of the
self-decrypting HTML page from causing the password from being sent over
the network, the JavaScript method `preventDefault()` was used.
However, this fails to take effect if the browser does not have
JavaScript enabled, and could ultimately lead to the password being
leaked to the network, which indeed happens with Lynx 2.8.9rel.1.

Hence set the action attribute explicitly to prevent the default action
from sending anything over the network. Also hide the form and display
a helpful message instead if the browser does not have JavaScript
enabled.